### PR TITLE
Added User-Agent for requests.

### DIFF
--- a/lib/github/auth/keys_client.rb
+++ b/lib/github/auth/keys_client.rb
@@ -9,6 +9,7 @@ module Github::Auth
     GithubUserDoesNotExistError = Class.new StandardError
 
     DEFAULT_HOSTNAME = 'https://api.github.com'
+    USER_AGENT = "github_auth-#{VERSION}"
 
     DEFAULT_OPTIONS = {
       username: nil,
@@ -30,7 +31,7 @@ module Github::Auth
     private
 
     def github_response
-      response = http_client.get "#{hostname}/users/#{username}/keys"
+      response = http_client.get("#{hostname}/users/#{username}/keys", :headers => headers)
         raise GithubUserDoesNotExistError if response.code == 404
       response.parsed_response
     rescue SocketError, Errno::ECONNREFUSED => e
@@ -39,6 +40,10 @@ module Github::Auth
 
     def http_client
       HTTParty
+    end
+
+    def headers
+      {"User-Agent" => USER_AGENT}
     end
   end
 end

--- a/spec/unit/github/auth/keys_client_spec.rb
+++ b/spec/unit/github/auth/keys_client_spec.rb
@@ -37,7 +37,8 @@ describe Github::Auth::KeysClient do
   describe '#keys' do
     it 'requests keys from the Github API' do
       http_client.should_receive(:get).with(
-        "https://api.github.com/users/#{username}/keys"
+        "https://api.github.com/users/#{username}/keys",
+        {:headers=>{"User-Agent"=>"github_auth-#{Github::Auth::VERSION}"}}
       )
       subject.keys
     end


### PR DESCRIPTION
```
$ gh-auth add USERNAME 
```

seems to be failing with the following error:

```
/gems/github-auth-0.2.0/lib/github/auth/keys_client.rb:27:in `block in keys': undefined method `fetch' for #<String:0xb7eef0f4> (NoMethodError)
```

This is due to the github api requiring a User-Agent to be sent with all requests.
# keys is undefined because the reponse from github is:

``` ruby
=> "{\"message\":\"Missing or invalid User Agent string. See http://developer.github.com/v3/#user-agent-required\"}"
```

This PR adds a User-Agent with the following format: 'github_auth-VERSION_NUMBER' to all requests it makes.

PS. Thanks for this gem!
