### PR TITLE
Add support to prefix the key with tmux support

### DIFF
--- a/lib/github/auth/cli.rb
+++ b/lib/github/auth/cli.rb
@@ -6,6 +6,7 @@ module Github::Auth
     COMMANDS = %w(add remove)
 
     def initialize(argv)
+      @tmux = argv.delete('--tmux')
       @command   = argv.shift
       @usernames = argv
     end
@@ -46,7 +47,8 @@ module Github::Auth
     end
 
     def print_usage
-      puts "usage: gh-auth [--version] [#{COMMANDS.join '|'}] <username>"
+      puts "usage: gh-auth [--version] [--tmux] " +
+       "[#{COMMANDS.join '|'}] <username>"
     end
 
     def print_version
@@ -81,6 +83,10 @@ module Github::Auth
       @keys ||= usernames.map { |username| keys_for username }.flatten.compact
     end
 
+    def tmux
+      @tmux || false
+    end
+
     def keys_for(username)
       Github::Auth::KeysClient.new(
         hostname: github_hostname,
@@ -93,7 +99,7 @@ module Github::Auth
     end
 
     def keys_file
-      Github::Auth::KeysFile.new path: keys_file_path
+      Github::Auth::KeysFile.new path: keys_file_path, tmux: tmux
     end
 
     def keys_file_path

--- a/spec/unit/github/auth/cli_spec.rb
+++ b/spec/unit/github/auth/cli_spec.rb
@@ -47,5 +47,15 @@ describe Github::Auth::CLI do
         subject.execute
       end
     end
+
+    context 'with the --tmux option' do
+      let(:action) { 'add' }
+      let(:argv) { ['--tmux', action, 'chrishunt'] }
+
+      it 'calls the method matching the action name' do
+        subject.should_receive(action)
+        subject.execute
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add the --tmux command line option
- Prefix the key in the authorized keys file with a command that
  immediately directs the pair to the tmux session when the option is added
- Remove tmux prefix and the key when the key is removed

This feature is based on the pairing setup here: http://www.zeespencer.com/articles/building-a-remote-pairing-setup/. I got tired of pasting the tmux prefix manually, so I added a command line option to add it for me.

Despite the spirt of pairing, I hackety-hacked this solo, so please let me know if you have any suggestions/improvements. Thanks!
