### PR TITLE
Adds a newline at the very end of the authorized_keys file

### DIFF
--- a/lib/github/auth/keys_file.rb
+++ b/lib/github/auth/keys_file.rb
@@ -16,8 +16,8 @@ module Github::Auth
       Array(keys).each do |key|
         unless keys_file_content.include? key.key
           append_keys_file do |keys_file|
-            keys_file.write "\n" unless keys_file_content.empty?
-            keys_file.write key
+            keys_file.write "\n" unless keys_file_content.empty? || keys_file_content.end_with?("\n")
+            keys_file.write "#{key}\n"
           end
         end
       end
@@ -57,7 +57,7 @@ module Github::Auth
           content.gsub! /#{Regexp.escape key.key}( .*)?$\n?/, ''
         end
 
-        content.strip!
+        content << "\n" unless content.empty? || content.end_with?("\n")
       end
     end
   end

--- a/spec/unit/github/auth/keys_file_spec.rb
+++ b/spec/unit/github/auth/keys_file_spec.rb
@@ -49,12 +49,10 @@ describe Github::Auth::KeysFile do
         end
       end
 
-      it 'does not leave a blank line' do
+      it 'includes a newline after the last key' do
         subject.write! keys
 
-        expect(
-          keys_file.readlines.select { |line| line =~ /^$\n/ }
-        ).to be_empty
+        expect(keys_file.read).to end_with("\n")
       end
     end
 
@@ -80,6 +78,7 @@ describe Github::Auth::KeysFile do
 
       before do
         keys_file.write existing_keys.join("\n")
+        keys_file.write "\n"
         keys_file.rewind
       end
 
@@ -132,6 +131,7 @@ describe Github::Auth::KeysFile do
 
     before do
       keys_file.write keys.join("\n")
+      keys_file.write "\n"
       keys_file.rewind
     end
 
@@ -152,12 +152,10 @@ describe Github::Auth::KeysFile do
         end
       end
 
-      it 'does not leave a blank line' do
-        subject.delete! key
+      it 'includes a newline after the last key' do
+        subject.write! keys
 
-        expect(
-          keys_file.readlines.select { |line| line =~ /^$\n/ }
-        ).to be_empty
+        expect(keys_file.read).to end_with("\n")
       end
     end
 


### PR DESCRIPTION
- This is important because it allows new keys to be added via `cat ...
  >> ~/.ssh/authorized_keys` or `echo ... >> ~/.ssh/authorized_keys`
  Without a newline at the end of the file `>>` will concat text to the
  end of the last key, mangling the file.
- These modifications should handle files that currently do _and_ do not
  have newlines at the very end, though it will always write files
  that _do_ have newlines at the very end.
