### PR TITLE
Addresses RSpec deprecation warnings

### DIFF
--- a/github-auth.gemspec
+++ b/github-auth.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'cane-hashcheck'
   spec.add_development_dependency 'coveralls'

--- a/spec/unit/github/auth/keys_client_spec.rb
+++ b/spec/unit/github/auth/keys_client_spec.rb
@@ -6,11 +6,11 @@ describe Github::Auth::KeysClient do
   subject { described_class.new username: username }
 
   let(:username) { 'chrishunt' }
-  let(:http_client) { stub('HttpClient', get: response) }
+  let(:http_client) { double('HttpClient', get: response) }
   let(:response_code) { 200 }
   let(:parsed_response) { nil }
   let(:response) {
-    stub('HTTParty::Response', {
+    double('HTTParty::Response', {
       code: response_code,
       parsed_response: parsed_response
     })


### PR DESCRIPTION
- `stub` is deprecated in favor of `double`
