### PR TITLE
Move --version test to acceptance

### DIFF
--- a/spec/acceptance/github/auth/cli_spec.rb
+++ b/spec/acceptance/github/auth/cli_spec.rb
@@ -43,5 +43,13 @@ describe Github::Auth::CLI do
 
       expect(output).to include('chrishunt')
     end
+
+    it 'prints version information' do
+      output = capture_stdout do
+        cli(%w(--version)).execute
+      end
+
+      expect(output).to include Github::Auth::VERSION
+    end
   end
 end

--- a/spec/unit/github/auth/cli_spec.rb
+++ b/spec/unit/github/auth/cli_spec.rb
@@ -38,14 +38,5 @@ describe Github::Auth::CLI do
         subject.execute
       end
     end
-
-    context 'with the --version command' do
-      let(:argv) { ['--version'] }
-
-      it 'prints version information' do
-        subject.should_receive(:print_version)
-        subject.execute
-      end
-    end
   end
 end


### PR DESCRIPTION
Thanks to the super helpful `capture_stdout` helper by @iamvery, we can now move this to an acceptance test.
