### PR TITLE
Bump to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+##v2.0.0
+*2013-10-22*
+
+[\[22 commits\]](https://github.com/chrishunt/github-auth/compare/v1.2.0...v2.0.0)
+
+*note:* Option syntax has changed in this release as a result of switching to
+`OptionParser`. See the [`README`](https://github.com/chrishunt/github-auth/blob/master/README.md)
+for usage instructions.
+
+- [Add `--list` command](https://github.com/chrishunt/github-auth/pull/14)
+- [Use `OptionParser` for parsing CLI options](https://github.com/chrishunt/github-auth/pull/16)
+
 ##v1.2.0
 *2013-08-20*
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-auth (1.2.0)
+    github-auth (2.0.0)
       httparty (~> 0.11.0)
 
 GEM

--- a/lib/github/auth/version.rb
+++ b/lib/github/auth/version.rb
@@ -1,5 +1,5 @@
 module Github
   module Auth
-    VERSION = "1.2.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
Includes #14, #16

Bumping major version because CLI syntax has changed, see [`README`](https://github.com/chrishunt/github-auth/blob/master/README.md)
