### PR TITLE
URL escape GitHub username

### DIFF
--- a/lib/github/auth/keys_client.rb
+++ b/lib/github/auth/keys_client.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'httparty'
 
 module Github::Auth
@@ -21,7 +22,7 @@ module Github::Auth
       options = DEFAULT_OPTIONS.merge options
       raise UsernameRequiredError unless options.fetch :username
 
-      @username = options.fetch :username
+      @username = CGI.escape(options.fetch :username)
       @hostname = options.fetch :hostname
     end
 

--- a/spec/unit/github/auth/keys_client_spec.rb
+++ b/spec/unit/github/auth/keys_client_spec.rb
@@ -33,6 +33,11 @@ describe Github::Auth::KeysClient do
       keys_client = described_class.new username: username
       expect(keys_client.username).to eq username
     end
+
+    it 'url escapes the username' do
+      keys_client = described_class.new username: 'spaces are !o.k.'
+      expect(keys_client.username).to eq 'spaces+are+%21o.k.'
+    end
   end
 
   describe '#keys' do


### PR DESCRIPTION
When we provide an invalid username:

``` bash
$ gh-auth add --users='!invalid'
```

We'll now see:

``` bash
Github user '!invalid' does not exist
Adding 0 key(s) to '/Users/chris/.ssh/authorized_keys'
```

Instead of:

``` bash
(URI::InvalidURIError)
```
