### PR TITLE
Rescue keys file errors for 'list' command

### DIFF
--- a/lib/github/auth/cli.rb
+++ b/lib/github/auth/cli.rb
@@ -53,7 +53,7 @@ module Github::Auth
         \x5> chrishunt, zachmargolis
     LONGDESC
     def list
-      puts keys_file.github_users.join(' ')
+      rescue_keys_file_errors { puts keys_file.github_users.join(' ') }
     end
 
     desc 'version', 'Show gh-auth version'


### PR DESCRIPTION
We'd like a pretty message when using the `list` command and the file does exists. We already do this for `add` and `remove`, so we'll use the same rescue blocks here.

We'll now see:

``` bash
$ gh-auth list --path=~/Desktop/does-not-exist
Keys file does not exist!

Create one now and try again:

  $ touch /Users/chris/Desktop/does-not-exist
```

Instead of:

``` bash
$ gh-auth list --path=~/Desktop/does-not-exist
No such file or directory - /Users/chris/Desktop/does-not-exist 
(Github::Auth::KeysFile::FileDoesNotExistError)
```
