### PR TITLE
remoteip.herokuapp.com is not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ $ su - pair
 You can get your external IP address with:
 
 ```bash
-$ curl http://remote-ip.herokuapp.com
+$ curl http://checkip.amazonaws.com/
 ```
 
 ### It's still not working! :(


### PR DESCRIPTION
AWS should have better reliability than a limited free service

Other alternatives that should work with CURL include:
- http://icanhazip.com/
- https://wtfismyip.com/text
- http://ifconfig.me/ip (or http://ifconfig.me/host for rdns)
- http://ipinfo.io/ip
- https://www.trackip.net/ip